### PR TITLE
SE-1010: Update individual project READMEs for monorepo setup

### DIFF
--- a/moonpay-react-buy/README.md
+++ b/moonpay-react-buy/README.md
@@ -1,36 +1,32 @@
 # MoonPay React SDK Demo - Buy
 
-## How to use:
+Demonstrates a **buy crypto** widget using [`@moonpay/moonpay-react`](https://www.npmjs.com/package/@moonpay/moonpay-react).
 
-**IMPORTANT NOTE:** Be sure to follow best practices with regards to the security of your API keys! This integration and the below instructions are for demo purposes only and it is expected that in production builds, API keys will not be exposed directly in 
-client-side files. It is the responsibility of the partner to rework and secure any integrations that originate from this directory.
+> **Disclaimer:** This is sample code for demo/testing purposes only. Never expose API keys in client-side code in production. See the security note in the [root README](../README.md).
 
-### Installing Dependencies
-**If you are using npm:**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
+## Quick Start
+
+All commands are run from the **monorepo root** (not this directory).
+
+```bash
+# 1. Install all dependencies (from repo root)
 npm install
+
+# 2. Configure environment variables
+cp server/.env.example server/.env   # add your MOONPAY_SECRET_KEY
+cp moonpay-react-buy/.env.example moonpay-react-buy/.env  # optional
+
+# 3. Start the shared signing server (port 5000)
+npm run start:server
+
+# 4. Start this demo (port 3000)
+npm run start:react-buy
 ```
 
-**If you are using Yarn**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
-yarn install
-```
+## What This Demo Does
 
-### Setting up your code:
-1. Replace the apiKey variable in MoonPayWidget.js with your API Key from the MoonPay Dashboard (dashboard.moonpay.com/developers).
-2. Replace secretKey in signUrl.mjs with your Secret Key from the MoonPay Dashboard (dashboard.moonpay.com/developers)
-3. If in production, allow-list your production domain on dashboard.moonpay.com/developers.
-4. If in production, you will need to change your fetch in line 13 of MoonPayWidget.js to reflect the URL of your signature endpoint.
+- Renders the MoonPay buy widget inside a React app (Vite)
+- Sends widget URLs to the shared `server/` signing server for HMAC-SHA256 signing
+- Runs on **port 3000** (Vite dev server); signing server on **port 5000**
 
-run `npm start` to start MoonPayWidget.js in the /src folder
-run `node signUrl.mjs` to start signUrl.mjs
+For full setup details, environment variables, and architecture, see the [root README](../README.md).

--- a/moonpay-react-sell-oninitiatedeposit/README.md
+++ b/moonpay-react-sell-oninitiatedeposit/README.md
@@ -1,37 +1,34 @@
-# MoonPay React SDK Demo - Buy with OnInitiateDeposit
+# MoonPay React SDK Demo - Sell with onInitiateDeposit
 
-## How to use:
+Demonstrates a **sell crypto** widget using [`@moonpay/moonpay-react`](https://www.npmjs.com/package/@moonpay/moonpay-react) with the `onInitiateDeposit` callback and a hosted wallet page for MetaMask transaction signing.
 
-**IMPORTANT NOTE:** Be sure to follow best practices with regards to the security of your API keys! This integration and the below instructions are for demo purposes only and it is expected that in production builds, API keys will not be exposed directly in 
-client-side files. It is the responsibility of the partner to rework and secure any integrations that originate from this directory.
+> **Disclaimer:** This is sample code for demo/testing purposes only. Never expose API keys in client-side code in production. See the security note in the [root README](../README.md).
 
-### Installing Dependencies
-**If you are using npm:**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
+## Quick Start
+
+All commands are run from the **monorepo root** (not this directory).
+
+```bash
+# 1. Install all dependencies (from repo root)
 npm install
+
+# 2. Configure environment variables
+cp server/.env.example server/.env   # add your MOONPAY_SECRET_KEY
+
+# 3. Start the shared signing server (port 5000)
+npm run start:server
+
+# 4. Start the sell widget (port 3000)
+npm run start:react-sell-deposit
+
+# 5. Start the hosted wallet page (port 3001) — in another terminal
+npm run start:wallet-page
 ```
 
-**If you are using Yarn**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
-yarn install
-```
+## What This Demo Does
 
-### Setting up your code:
-1. In react-widget-integration, replace the apiKey variable in MoonPayWidget.js with your API Key from the MoonPay Dashboard (dashboard.moonpay.com/developers).
-2. Replace secretKey in signUrl.mjs with your Secret Key from the MoonPay Dashboard (dashboard.moonpay.com/developers)
-3. If in production, allow-list your production domain on dashboard.moonpay.com/developers.
-4. If in production, you will need to change your fetch in line 14 of MoonPayWidget.js to reflect the URL of your signature endpoint.
+- **react-widget-integration/**: React app with the MoonPay sell widget that uses the `onInitiateDeposit` callback to hand off crypto deposit signing to a hosted wallet page
+- **hosted-wallet-page/**: Standalone page that connects to MetaMask and signs the deposit transaction
+- Widget runs on **port 3000**, wallet page on **port 3001**, signing server on **port 5000**
 
-run `npm start` to start MoonPayWidget.js in the /src folder
-run `node signUrl.mjs` to start signUrl.mjs
-run `npm start` to start App.js in the /src folder of hosted-wallet-page
+For full setup details, environment variables, and architecture, see the [root README](../README.md).

--- a/moonpay-react-sell/README.md
+++ b/moonpay-react-sell/README.md
@@ -1,36 +1,32 @@
 # MoonPay React SDK Demo - Sell
 
-## How to use:
+Demonstrates a **sell crypto** widget using [`@moonpay/moonpay-react`](https://www.npmjs.com/package/@moonpay/moonpay-react).
 
-**IMPORTANT NOTE:** Be sure to follow best practices with regards to the security of your API keys! This integration and the below instructions are for demo purposes only and it is expected that in production builds, API keys will not be exposed directly in 
-client-side files. It is the responsibility of the partner to rework and secure any integrations that originate from this directory.
+> **Disclaimer:** This is sample code for demo/testing purposes only. Never expose API keys in client-side code in production. See the security note in the [root README](../README.md).
 
-### Installing Dependencies
-**If you are using npm:**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
+## Quick Start
+
+All commands are run from the **monorepo root** (not this directory).
+
+```bash
+# 1. Install all dependencies (from repo root)
 npm install
+
+# 2. Configure environment variables
+cp server/.env.example server/.env   # add your MOONPAY_SECRET_KEY
+cp moonpay-react-sell/.env.example moonpay-react-sell/.env  # optional
+
+# 3. Start the shared signing server (port 5000)
+npm run start:server
+
+# 4. Start this demo (port 3000)
+npm run start:react-sell
 ```
 
-**If you are using Yarn**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
-yarn install
-```
+## What This Demo Does
 
-### Setting up your code:
-1. Replace the apiKey variable in MoonPayWidget.js with your API Key from the MoonPay Dashboard (dashboard.moonpay.com/developers)
-2. Replace secretKey in signUrl.mjs with your Secret Key from the MoonPay Dashboard (dashboard.moonpay.com/developers)
-3. If in production, allow-list your production domain on dashboard.moonpay.com/developers.
-4. If in production, you will need to change your fetch in line 13 of MoonPayWidget.js to reflect the URL of your signature endpoint.
+- Renders the MoonPay sell widget inside a React app (Vite)
+- Sends widget URLs to the shared `server/` signing server for HMAC-SHA256 signing
+- Runs on **port 3000** (Vite dev server); signing server on **port 5000**
 
-run `npm start` to start MoonPayWidget.js in the /src folder
-run `node signUrl.mjs` to start signUrl.mjs
+For full setup details, environment variables, and architecture, see the [root README](../README.md).

--- a/moonpay-websdk-buy/README.md
+++ b/moonpay-websdk-buy/README.md
@@ -1,40 +1,31 @@
-# MoonPay Web SDK - Buy
+# MoonPay Web SDK Demo - Buy
 
-**IMPORTANT NOTE:** Be sure to follow best practices with regards to the security of your API keys! This integration and the below instructions are for demo purposes only and it is expected that in production builds, API keys will not be exposed directly in 
-client-side files. It is the responsibility of the partner to rework and secure any integrations that originate from this directory.
+Demonstrates a **buy crypto** widget using [`@moonpay/moonpay-js`](https://www.npmjs.com/package/@moonpay/moonpay-js) (vanilla JavaScript, loaded via CDN).
 
-### Installing Dependencies
-**If you are using npm:**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
+> **Disclaimer:** This is sample code for demo/testing purposes only. Never expose API keys in client-side code in production. See the security note in the [root README](../README.md).
+
+## Quick Start
+
+All commands are run from the **monorepo root** (not this directory).
+
+```bash
+# 1. Install all dependencies (from repo root)
 npm install
+
+# 2. Configure environment variables
+cp server/.env.example server/.env   # add your MOONPAY_SECRET_KEY
+
+# 3. Start the shared signing server (port 5000)
+npm run start:server
+
+# 4. Start this demo (port 8080)
+npm run start:websdk-buy
 ```
 
-**If you are using Yarn**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
-yarn install
-```
+## What This Demo Does
 
-### Setting up your code:
-1. Replace the apiKey variable in index.js with your API Key from the MoonPay Dashboard (dashboard.moonpay.com/developers)
-2. Replace secretKey in signUrl.mjs with your Secret Key from the MoonPay Dashboard (dashboard.moonpay.com/developers)
-3. If running locally, set up your integration on a port.\
-    To do this:\
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;a. Navigate to the directory containing index.html and index.js\
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b. Run python -m http.server 8080\
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;c. You may also run "python3", as well as modify the port on which you deploy.\
-4. To view your integration, navigate to 'http://localhost:8080' in your browser
-5. If moving to production, along with switching to live API keys and "environment:" to "production" in index.js, make sure that the URL in line 55 of index.js is set to buy.moonpay.com instead of buy-sandbox.moonpay.com
-6. Allow-list your production domain on dashboard.moonpay.com/developers
+- Loads the MoonPay buy widget via the Web SDK (no framework required)
+- Sends widget URLs to the shared `server/` signing server for HMAC-SHA256 signing
+- Runs on **port 8080** (live-server); signing server on **port 5000**
 
-run `npm start` to start index.js\
-run `node signUrl.mjs` to start signUrl.mjs
+For full setup details, environment variables, and architecture, see the [root README](../README.md).

--- a/moonpay-websdk-sell/README.md
+++ b/moonpay-websdk-sell/README.md
@@ -1,40 +1,31 @@
-# MoonPay Web SDK - Sell
+# MoonPay Web SDK Demo - Sell
 
-**IMPORTANT NOTE:** Be sure to follow best practices with regards to the security of your API keys! This integration and the below instructions are for demo purposes only and it is expected that in production builds, API keys will not be exposed directly in 
-client-side files. It is the responsibility of the partner to rework and secure any integrations that originate from this directory.
+Demonstrates a **sell crypto** widget using [`@moonpay/moonpay-js`](https://www.npmjs.com/package/@moonpay/moonpay-js) (vanilla JavaScript, loaded via CDN).
 
-### Installing Dependencies
-**If you are using npm:**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
+> **Disclaimer:** This is sample code for demo/testing purposes only. Never expose API keys in client-side code in production. See the security note in the [root README](../README.md).
+
+## Quick Start
+
+All commands are run from the **monorepo root** (not this directory).
+
+```bash
+# 1. Install all dependencies (from repo root)
 npm install
+
+# 2. Configure environment variables
+cp server/.env.example server/.env   # add your MOONPAY_SECRET_KEY
+
+# 3. Start the shared signing server (port 5000)
+npm run start:server
+
+# 4. Start this demo (port 8080)
+npm run start:websdk-sell
 ```
 
-**If you are using Yarn**
-1. Navigate to the project directory after cloning
-```
-cd /path/to/your/repo
-```
-2. Run the following command to install all the dependencies listed in package.json:
-```
-yarn install
-```
+## What This Demo Does
 
-### Setting up your code:
-1. Replace the apiKey variable in index.js with your API Key from the MoonPay Dashboard (dashboard.moonpay.com/developers)
-2. Replace secretKey in signUrl.mjs with your Secret Key from the MoonPay Dashboard (dashboard.moonpay.com/developers)
-3. If running locally, set up your integration on a port.\
-    To do this:\
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;a. Navigate to the directory containing index.html and index.js\
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b. Run python -m http.server 8080\
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;c. You may also run "python3", as well as modify the port on which you deploy.\
-4. To view your integration, navigate to 'http://localhost:8080' in your browser
-5. If moving to production, along with switching to live API keys and "environment:" to "production" in index.js, make sure that the URL in line 55 of index.js is set to buy.moonpay.com instead of buy-sandbox.moonpay.com
-6. Allow-list your production domain on dashboard.moonpay.com/developers
+- Loads the MoonPay sell widget via the Web SDK (no framework required)
+- Sends widget URLs to the shared `server/` signing server for HMAC-SHA256 signing
+- Runs on **port 8080** (live-server); signing server on **port 5000**
 
-run `npm start` to start index.js\
-run `node signUrl.mjs` to start signUrl.mjs
+For full setup details, environment variables, and architecture, see the [root README](../README.md).


### PR DESCRIPTION
## Summary

- Updated all 5 project READMEs (`moonpay-react-buy`, `moonpay-react-sell`, `moonpay-websdk-buy`, `moonpay-websdk-sell`, `moonpay-react-sell-oninitiatedeposit`) to reflect the monorepo setup
- Replaced outdated standalone instructions (per-directory `npm install`, per-project `signUrl.mjs`) with correct monorepo workflow: root-level `npm install`, shared `server/` signing server, and workspace-level npm scripts
- Each README now includes correct port numbers and links back to the root README for full setup details

## Test plan

- [ ] Verify each project README renders correctly on GitHub
- [ ] Confirm all referenced npm scripts (`npm run start:server`, `npm run start:react-buy`, etc.) match those in the root `package.json`
- [ ] Confirm port numbers match the root README port table (3000, 3001, 5000, 8080)

🤖 Generated with [Claude Code](https://claude.com/claude-code)