### PR TITLE
SE-1008: Standardize .env.example files across all projects

### DIFF
--- a/moonpay-react-sell-oninitiatedeposit/hosted-wallet-page/.env.example
+++ b/moonpay-react-sell-oninitiatedeposit/hosted-wallet-page/.env.example
@@ -1,0 +1,5 @@
+# Hosted Wallet Page — no API keys required
+# This project serves as a standalone wallet page for the onInitiateDeposit flow.
+
+# Vite dev server port (optional, defaults to 5173)
+VITE_PORT=5173

--- a/moonpay-websdk-buy/.env.example
+++ b/moonpay-websdk-buy/.env.example
@@ -1,7 +1,10 @@
-# MoonPay API Key (public) — used in index.js (replace the placeholder there manually)
+# MoonPay API Key (public) — used by the WebSDK frontend
 # Get yours at https://dashboard.moonpay.com/developers
 MOONPAY_API_KEY=pk_test_your_api_key_here
 
 # MoonPay Secret Key (private) — used by signUrl.mjs backend only
 # NEVER expose this in frontend code
 MOONPAY_SECRET_KEY=sk_test_your_secret_key_here
+
+# Signing server URL — points to the local Express signing server
+SIGNING_SERVER_URL=http://localhost:5000

--- a/moonpay-websdk-sell/.env.example
+++ b/moonpay-websdk-sell/.env.example
@@ -1,7 +1,10 @@
-# MoonPay API Key (public) — used in index.js (replace the placeholder there manually)
+# MoonPay API Key (public) — used by the WebSDK frontend
 # Get yours at https://dashboard.moonpay.com/developers
 MOONPAY_API_KEY=pk_test_your_api_key_here
 
 # MoonPay Secret Key (private) — used by signUrl.mjs backend only
 # NEVER expose this in frontend code
 MOONPAY_SECRET_KEY=sk_test_your_secret_key_here
+
+# Signing server URL — points to the local Express signing server
+SIGNING_SERVER_URL=http://localhost:5000


### PR DESCRIPTION
## Summary
- Created missing `.env.example` for `hosted-wallet-page` (minimal, no API keys needed)
- Added `SIGNING_SERVER_URL=http://localhost:5000` to both WebSDK `.env.example` files (`moonpay-websdk-buy`, `moonpay-websdk-sell`)
- Standardized inline comments across all `.env.example` files for consistency (replaced implementation-specific notes like "used in index.js" with clearer descriptions like "used by the WebSDK frontend")

## Test plan
- [ ] Verify `moonpay-react-sell-oninitiatedeposit/hosted-wallet-page/.env.example` exists and is minimal
- [ ] Verify `moonpay-websdk-buy/.env.example` includes `SIGNING_SERVER_URL`
- [ ] Verify `moonpay-websdk-sell/.env.example` includes `SIGNING_SERVER_URL`
- [ ] Verify comment style is consistent across all `.env.example` files
- [ ] Confirm no actual secrets are included in any `.env.example` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)